### PR TITLE
Add Filter Enchantment Option

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/Methods.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/Methods.java
@@ -425,6 +425,15 @@ public class Methods {
     public static boolean verifyItemLore(ItemStack item) {
         return item != null && item.getItemMeta() != null && item.hasItemMeta() && item.getItemMeta().getLore() != null && item.getItemMeta().hasLore();
     }
+
+    /**
+     * Verify the ItemStack has a display name. This checks to make sure everything isn't null because recent minecraft updates cause NPEs.
+     * @param item Itemstack you are checking.
+     * @return True if the item has a display name and no null issues.
+     */
+    public static boolean verifyItemDisplayName(ItemStack item) {
+        return item != null && item.getItemMeta() != null && item.hasItemMeta() && item.getItemMeta().hasDisplayName();
+    }
     
     public static HashMap<String, String> getEnchantments() {
         HashMap<String, String> enchantments = new HashMap<>();

--- a/plugin/src/main/java/me/badbones69/crazyenchantments/api/CrazyEnchantments.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/api/CrazyEnchantments.java
@@ -54,6 +54,7 @@ public class CrazyEnchantments {
     private boolean enchantStackedItems;
     private boolean maxEnchantmentCheck;
     private boolean checkVanillaLimit;
+    private boolean filterIsWhitelist;
     private ItemBuilder enchantmentBook;
     private NMSSupport nmsSupport;
     private Random random = new Random();
@@ -74,6 +75,8 @@ public class CrazyEnchantments {
     private List<CEnchantment> registeredEnchantments = new ArrayList<>();
     private List<Event> ignoredEvents = new ArrayList<>();
     private List<UUID> ignoredUUIDs = new ArrayList<>();
+    private List<String> filterNames = new ArrayList<>();
+    private List<String> filterLore = new ArrayList<>();
     
     public static CrazyEnchantments getInstance() {
         return instance;
@@ -116,6 +119,9 @@ public class CrazyEnchantments {
         rageMaxLevel = config.contains("Settings.EnchantmentOptions.MaxRageLevel") ? config.getInt("Settings.EnchantmentOptions.MaxRageLevel") : 4;
         breakRageOnDamage = !config.contains("Settings.EnchantmentOptions.Break-Rage-On-Damage") || config.getBoolean("Settings.EnchantmentOptions.Break-Rage-On-Damage");
         enchantStackedItems = config.contains("Settings.EnchantmentOptions.Enchant-Stacked-Items") && config.getBoolean("Settings.EnchantmentOptions.Enchant-Stacked-Items");
+        filterIsWhitelist = config.getBoolean("Settings.EnchantmentOptions.Filter.Is-Whitelist");
+        filterNames = config.getStringList("Settings.EnchantmentOptions.Filter.Names");
+        filterLore = config.getStringList("Settings.EnchantmentOptions.Filter.Lore");
         for (String category : config.getConfigurationSection("Categories").getKeys(false)) {
             String path = "Categories." + category;
             LostBook lostBook = new LostBook(
@@ -1494,6 +1500,30 @@ public class CrazyEnchantments {
             }
         }
         return colors;
+    }
+
+    /**
+     * Get if the item filter mode is whitelist or blacklist
+     * @return True if filter mode is whitelist, False if filter mode is blacklist
+     */
+    public boolean isFilterWhitelist() {
+        return filterIsWhitelist;
+    }
+
+    /**
+     * Get the list of names to be filtered when applying enchantments
+     * @return String List of names to be filtered
+     */
+    public List<String> getFilterNames() {
+        return filterNames;
+    }
+
+    /**
+     * Get the list of lore to be filtered when applying enchantments
+     * @return String List of lore to be filtered
+     */
+    public List<String> getFilterLore() {
+        return filterLore;
     }
     
 }

--- a/plugin/src/main/java/me/badbones69/crazyenchantments/controllers/EnchantmentControl.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/controllers/EnchantmentControl.java
@@ -14,6 +14,7 @@ import me.badbones69.crazyenchantments.api.objects.CEBook;
 import me.badbones69.crazyenchantments.api.objects.CEnchantment;
 import me.badbones69.crazyenchantments.multisupport.Version;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -26,9 +27,11 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.HashMap;
+import java.util.List;
 
 public class EnchantmentControl implements Listener {
     
@@ -44,130 +47,149 @@ public class EnchantmentControl implements Listener {
                 CEBook ceBook = ce.getCEBook(e.getCursor());
                 CEnchantment enchantment = ceBook.getEnchantment();
                 if (enchantment != null && enchantment.canEnchantItem(item) && ceBook.getAmount() == 1) {
-                    Player player = (Player) e.getWhoClicked();
-                    if (ce.enchantStackedItems() || item.getAmount() == 1) {
-                        boolean success = Methods.randomPicker(ceBook.getSuccessRate(), 100);
-                        boolean destroy = Methods.randomPicker(ceBook.getDestroyRate(), 100);
-                        int bookLevel = ceBook.getLevel();
-                        boolean hasEnchantment = false;
-                        boolean isLowerLevel = false;
-                        if (ce.hasEnchantment(item, enchantment)) {
-                            hasEnchantment = true;
-                            if (ce.getLevel(item, enchantment) < bookLevel) {
-                                isLowerLevel = true;
+                    boolean applyEnchant = !ce.isFilterWhitelist();
+                    if (Methods.verifyItemDisplayName(item)) {
+                        for (String name : ce.getFilterNames()) {
+                            if (item.getItemMeta().getDisplayName().equals(ChatColor.translateAlternateColorCodes('&', name))) {
+                                applyEnchant = ce.isFilterWhitelist();
+                                break;
                             }
-                        }
-                        if (hasEnchantment) {
-                            if (Files.CONFIG.getFile().getBoolean("Settings.EnchantmentOptions.Armor-Upgrade.Toggle") && isLowerLevel) {
-                                e.setCancelled(true);
-                                PreBookApplyEvent preBookApplyEvent = new PreBookApplyEvent(player, item, ceBook, player.getGameMode() == GameMode.CREATIVE, success, destroy);
-                                Bukkit.getPluginManager().callEvent(preBookApplyEvent);
-                                if (!preBookApplyEvent.isCancelled()) {
-                                    if (success || player.getGameMode() == GameMode.CREATIVE) {
-                                        BookFailEvent bookApplyEvent = new BookFailEvent(player, item, ceBook);
-                                        Bukkit.getPluginManager().callEvent(bookApplyEvent);
-                                        if (!bookApplyEvent.isCancelled()) {
-                                            e.setCurrentItem(ce.addEnchantment(item, enchantment, bookLevel));
-                                            player.setItemOnCursor(new ItemStack(Material.AIR));
-                                            HashMap<String, String> placeholders = new HashMap<>();
-                                            placeholders.put("%Enchantment%", enchantment.getCustomName());
-                                            placeholders.put("%Level%", bookLevel + "");
-                                            player.sendMessage(Messages.ENCHANTMENT_UPGRADE_SUCCESS.getMessage(placeholders));
-                                            player.playSound(player.getLocation(), ce.getSound("ENTITY_PLAYER_LEVELUP", "LEVEL_UP"), 1, 1);
-                                        }
-                                        return;
-                                    } else if (destroy) {
-                                        BookDestroyEvent bookDestroyEvent = new BookDestroyEvent(player, item, ceBook);
-                                        Bukkit.getPluginManager().callEvent(bookDestroyEvent);
-                                        if (!bookDestroyEvent.isCancelled()) {
-                                            if (Files.CONFIG.getFile().getBoolean("Settings.EnchantmentOptions.Armor-Upgrade.Enchantment-Break")) {
-                                                if (ce.hasWhiteScrollProtection(item)) {
-                                                    e.setCurrentItem(ce.removeWhiteScrollProtection(item));
-                                                    player.sendMessage(Messages.ITEM_WAS_PROTECTED.getMessage());
-                                                } else {
-                                                    ItemStack newItem = ce.removeEnchantment(item, enchantment);
-                                                    if (e.getInventory().getType() == InventoryType.CRAFTING && e.getRawSlot() >= 5 && e.getRawSlot() <= 8) {
-                                                        ArmorEquipEvent event = new ArmorEquipEvent(player, EquipMethod.DRAG, ArmorType.matchType(item), item, newItem);
-                                                        Bukkit.getPluginManager().callEvent(event);
-                                                    }
-                                                    player.sendMessage(Messages.ENCHANTMENT_UPGRADE_DESTROYED.getMessage());
-                                                }
-                                            } else {
-                                                if (ce.hasWhiteScrollProtection(item)) {
-                                                    e.setCurrentItem(ce.removeWhiteScrollProtection(item));
-                                                    player.sendMessage(Messages.ITEM_WAS_PROTECTED.getMessage());
-                                                } else {
-                                                    ItemStack newItem = new ItemStack(Material.AIR);
-                                                    e.setCurrentItem(newItem);
-                                                    if (e.getInventory().getType() == InventoryType.CRAFTING && e.getRawSlot() >= 5 && e.getRawSlot() <= 8) {
-                                                        ArmorEquipEvent event = new ArmorEquipEvent(player, EquipMethod.BROKE, ArmorType.matchType(item), item, newItem);
-                                                        Bukkit.getPluginManager().callEvent(event);
-                                                    }
-                                                    player.sendMessage(Messages.ITEM_DESTROYED.getMessage());
-                                                }
-                                            }
-                                            player.setItemOnCursor(new ItemStack(Material.AIR));
-                                            player.playSound(player.getLocation(), ce.getSound("ENTITY_ITEM_BREAK", "ITEM_BREAK"), 1, 1);
-                                        }
-                                        return;
-                                    } else {
-                                        BookFailEvent bookFailEvent = new BookFailEvent(player, item, ceBook);
-                                        Bukkit.getPluginManager().callEvent(bookFailEvent);
-                                        if (!bookFailEvent.isCancelled()) {
-                                            player.setItemOnCursor(new ItemStack(Material.AIR));
-                                            player.sendMessage(Messages.ENCHANTMENT_UPGRADE_FAILED.getMessage());
-                                            player.playSound(player.getLocation(), ce.getSound("ENTITY_ITEM_BREAK", "ITEM_BREAK"), 1, 1);
-                                        }
-                                        return;
-                                    }
-                                }
-                            }
-                            return;
-                        }
-                        if (!ce.canAddEnchantment(player, item)) {
-                            player.sendMessage(Messages.HIT_ENCHANTMENT_MAX.getMessage());
-                            return;
-                        }
-                        e.setCancelled(true);
-                        if (success || player.getGameMode() == GameMode.CREATIVE) {
-                            ItemStack newItem = ce.addEnchantment(item, enchantment, ceBook.getLevel());
-                            ItemStack oldItem = new ItemStack(Material.AIR);
-                            e.setCurrentItem(newItem);
-                            if (e.getInventory().getType() == InventoryType.CRAFTING && e.getRawSlot() >= 5 && e.getRawSlot() <= 8) {
-                                ArmorEquipEvent event = new ArmorEquipEvent(player, EquipMethod.DRAG, ArmorType.matchType(item), oldItem, newItem);
-                                Bukkit.getPluginManager().callEvent(event);
-                            }
-                            player.setItemOnCursor(new ItemStack(Material.AIR));
-                            player.sendMessage(Messages.BOOK_WORKS.getMessage());
-                            player.playSound(player.getLocation(), ce.getSound("ENTITY_PLAYER_LEVELUP", "LEVEL_UP"), 1, 1);
-                            return;
-                        }
-                        if (destroy) {
-                            if (ce.hasWhiteScrollProtection(item)) {
-                                e.setCurrentItem(ce.removeWhiteScrollProtection(item));
-                                player.setItemOnCursor(new ItemStack(Material.AIR));
-                                player.sendMessage(Messages.ITEM_WAS_PROTECTED.getMessage());
-                                player.playSound(player.getLocation(), ce.getSound("ENTITY_ITEM_BREAK", "ITEM_BREAK"), 1, 1);
-                                return;
-                            } else {
-                                ItemStack newItem = new ItemStack(Material.AIR);
-                                ItemStack oldItem = new ItemStack(Material.AIR);
-                                player.setItemOnCursor(newItem);
-                                if (e.getInventory().getType() == InventoryType.CRAFTING && e.getRawSlot() >= 5 && e.getRawSlot() <= 8) {
-                                    ArmorEquipEvent event = new ArmorEquipEvent(player, EquipMethod.BROKE, ArmorType.matchType(item), item, newItem);
-                                    Bukkit.getPluginManager().callEvent(event);
-                                }
-                                e.setCurrentItem(oldItem);
-                                player.sendMessage(Messages.ITEM_DESTROYED.getMessage());
-                            }
-                            player.updateInventory();
-                            return;
                         }
                     }
-                    player.sendMessage(Messages.BOOK_FAILED.getMessage());
-                    player.setItemOnCursor(new ItemStack(Material.AIR));
-                    player.playSound(player.getLocation(), ce.getSound("ENTITY_ITEM_BREAK", "ITEM_BREAK"), 1, 1);
-                    player.updateInventory();
+                    if (applyEnchant == !ce.isFilterWhitelist() && Methods.verifyItemLore(item)) {
+                        for (String lore : ce.getFilterLore()) {
+                            if (item.getItemMeta().getLore().contains(ChatColor.translateAlternateColorCodes('&', lore))) {
+                                applyEnchant = ce.isFilterWhitelist();
+                                break;
+                            }
+                        }
+                    }
+                    if (applyEnchant) {
+                        Player player = (Player) e.getWhoClicked();
+                        if (ce.enchantStackedItems() || item.getAmount() == 1) {
+                            boolean success = Methods.randomPicker(ceBook.getSuccessRate(), 100);
+                            boolean destroy = Methods.randomPicker(ceBook.getDestroyRate(), 100);
+                            int bookLevel = ceBook.getLevel();
+                            boolean hasEnchantment = false;
+                            boolean isLowerLevel = false;
+                            if (ce.hasEnchantment(item, enchantment)) {
+                                hasEnchantment = true;
+                                if (ce.getLevel(item, enchantment) < bookLevel) {
+                                    isLowerLevel = true;
+                                }
+                            }
+                            if (hasEnchantment) {
+                                if (Files.CONFIG.getFile().getBoolean("Settings.EnchantmentOptions.Armor-Upgrade.Toggle") && isLowerLevel) {
+                                    e.setCancelled(true);
+                                    PreBookApplyEvent preBookApplyEvent = new PreBookApplyEvent(player, item, ceBook, player.getGameMode() == GameMode.CREATIVE, success, destroy);
+                                    Bukkit.getPluginManager().callEvent(preBookApplyEvent);
+                                    if (!preBookApplyEvent.isCancelled()) {
+                                        if (success || player.getGameMode() == GameMode.CREATIVE) {
+                                            BookFailEvent bookApplyEvent = new BookFailEvent(player, item, ceBook);
+                                            Bukkit.getPluginManager().callEvent(bookApplyEvent);
+                                            if (!bookApplyEvent.isCancelled()) {
+                                                e.setCurrentItem(ce.addEnchantment(item, enchantment, bookLevel));
+                                                player.setItemOnCursor(new ItemStack(Material.AIR));
+                                                HashMap<String, String> placeholders = new HashMap<>();
+                                                placeholders.put("%Enchantment%", enchantment.getCustomName());
+                                                placeholders.put("%Level%", bookLevel + "");
+                                                player.sendMessage(Messages.ENCHANTMENT_UPGRADE_SUCCESS.getMessage(placeholders));
+                                                player.playSound(player.getLocation(), ce.getSound("ENTITY_PLAYER_LEVELUP", "LEVEL_UP"), 1, 1);
+                                            }
+                                            return;
+                                        } else if (destroy) {
+                                            BookDestroyEvent bookDestroyEvent = new BookDestroyEvent(player, item, ceBook);
+                                            Bukkit.getPluginManager().callEvent(bookDestroyEvent);
+                                            if (!bookDestroyEvent.isCancelled()) {
+                                                if (Files.CONFIG.getFile().getBoolean("Settings.EnchantmentOptions.Armor-Upgrade.Enchantment-Break")) {
+                                                    if (ce.hasWhiteScrollProtection(item)) {
+                                                        e.setCurrentItem(ce.removeWhiteScrollProtection(item));
+                                                        player.sendMessage(Messages.ITEM_WAS_PROTECTED.getMessage());
+                                                    } else {
+                                                        ItemStack newItem = ce.removeEnchantment(item, enchantment);
+                                                        if (e.getInventory().getType() == InventoryType.CRAFTING && e.getRawSlot() >= 5 && e.getRawSlot() <= 8) {
+                                                            ArmorEquipEvent event = new ArmorEquipEvent(player, EquipMethod.DRAG, ArmorType.matchType(item), item, newItem);
+                                                            Bukkit.getPluginManager().callEvent(event);
+                                                        }
+                                                        player.sendMessage(Messages.ENCHANTMENT_UPGRADE_DESTROYED.getMessage());
+                                                    }
+                                                } else {
+                                                    if (ce.hasWhiteScrollProtection(item)) {
+                                                        e.setCurrentItem(ce.removeWhiteScrollProtection(item));
+                                                        player.sendMessage(Messages.ITEM_WAS_PROTECTED.getMessage());
+                                                    } else {
+                                                        ItemStack newItem = new ItemStack(Material.AIR);
+                                                        e.setCurrentItem(newItem);
+                                                        if (e.getInventory().getType() == InventoryType.CRAFTING && e.getRawSlot() >= 5 && e.getRawSlot() <= 8) {
+                                                            ArmorEquipEvent event = new ArmorEquipEvent(player, EquipMethod.BROKE, ArmorType.matchType(item), item, newItem);
+                                                            Bukkit.getPluginManager().callEvent(event);
+                                                        }
+                                                        player.sendMessage(Messages.ITEM_DESTROYED.getMessage());
+                                                    }
+                                                }
+                                                player.setItemOnCursor(new ItemStack(Material.AIR));
+                                                player.playSound(player.getLocation(), ce.getSound("ENTITY_ITEM_BREAK", "ITEM_BREAK"), 1, 1);
+                                            }
+                                            return;
+                                        } else {
+                                            BookFailEvent bookFailEvent = new BookFailEvent(player, item, ceBook);
+                                            Bukkit.getPluginManager().callEvent(bookFailEvent);
+                                            if (!bookFailEvent.isCancelled()) {
+                                                player.setItemOnCursor(new ItemStack(Material.AIR));
+                                                player.sendMessage(Messages.ENCHANTMENT_UPGRADE_FAILED.getMessage());
+                                                player.playSound(player.getLocation(), ce.getSound("ENTITY_ITEM_BREAK", "ITEM_BREAK"), 1, 1);
+                                            }
+                                            return;
+                                        }
+                                    }
+                                }
+                                return;
+                            }
+                            if (!ce.canAddEnchantment(player, item)) {
+                                player.sendMessage(Messages.HIT_ENCHANTMENT_MAX.getMessage());
+                                return;
+                            }
+                            e.setCancelled(true);
+                            if (success || player.getGameMode() == GameMode.CREATIVE) {
+                                ItemStack newItem = ce.addEnchantment(item, enchantment, ceBook.getLevel());
+                                ItemStack oldItem = new ItemStack(Material.AIR);
+                                e.setCurrentItem(newItem);
+                                if (e.getInventory().getType() == InventoryType.CRAFTING && e.getRawSlot() >= 5 && e.getRawSlot() <= 8) {
+                                    ArmorEquipEvent event = new ArmorEquipEvent(player, EquipMethod.DRAG, ArmorType.matchType(item), oldItem, newItem);
+                                    Bukkit.getPluginManager().callEvent(event);
+                                }
+                                player.setItemOnCursor(new ItemStack(Material.AIR));
+                                player.sendMessage(Messages.BOOK_WORKS.getMessage());
+                                player.playSound(player.getLocation(), ce.getSound("ENTITY_PLAYER_LEVELUP", "LEVEL_UP"), 1, 1);
+                                return;
+                            }
+                            if (destroy) {
+                                if (ce.hasWhiteScrollProtection(item)) {
+                                    e.setCurrentItem(ce.removeWhiteScrollProtection(item));
+                                    player.setItemOnCursor(new ItemStack(Material.AIR));
+                                    player.sendMessage(Messages.ITEM_WAS_PROTECTED.getMessage());
+                                    player.playSound(player.getLocation(), ce.getSound("ENTITY_ITEM_BREAK", "ITEM_BREAK"), 1, 1);
+                                    return;
+                                } else {
+                                    ItemStack newItem = new ItemStack(Material.AIR);
+                                    ItemStack oldItem = new ItemStack(Material.AIR);
+                                    player.setItemOnCursor(newItem);
+                                    if (e.getInventory().getType() == InventoryType.CRAFTING && e.getRawSlot() >= 5 && e.getRawSlot() <= 8) {
+                                        ArmorEquipEvent event = new ArmorEquipEvent(player, EquipMethod.BROKE, ArmorType.matchType(item), item, newItem);
+                                        Bukkit.getPluginManager().callEvent(event);
+                                    }
+                                    e.setCurrentItem(oldItem);
+                                    player.sendMessage(Messages.ITEM_DESTROYED.getMessage());
+                                }
+                                player.updateInventory();
+                                return;
+                            }
+                        }
+                        player.sendMessage(Messages.BOOK_FAILED.getMessage());
+                        player.setItemOnCursor(new ItemStack(Material.AIR));
+                        player.playSound(player.getLocation(), ce.getSound("ENTITY_ITEM_BREAK", "ITEM_BREAK"), 1, 1);
+                        player.updateInventory();
+                    }
                 }
             }
         }

--- a/plugin/src/main/resources/config1.12.2-Down.yml
+++ b/plugin/src/main/resources/config1.12.2-Down.yml
@@ -286,6 +286,14 @@ Settings:
           - 'Hub_Example'
         Blacklisted: #Wings will not work at all in these worlds regardless of regions.
           - 'SkyBlock_Example'
+    Filter: #Filter which items can or can't receive enchantments based on name or lore
+      Names: #Matches if the item name is in this list
+        - '&aSome Custom Item Name'
+        - '&e&lAnother &bCustom Item'
+      Lore: #Matches if a single line of item lore is in this list
+        - '&fExample Item Lore'
+        - '&eMore Example Lore'
+      Is-Whitelist: false #If true, enchantments will only be applied to items matching name or lore. If false, enchantments won't be applied to items matching name or lore.
   Costs: #This is where you set the cost of stuff in the shop GUI.
     Scrambler: #The item that is being bought.
       Cost: 800 #How much the item will cost.

--- a/plugin/src/main/resources/config1.13-Up.yml
+++ b/plugin/src/main/resources/config1.13-Up.yml
@@ -285,6 +285,14 @@ Settings:
           - 'Hub_Example'
         Blacklisted: #Wings will not work at all in these worlds regardless of regions.
           - 'SkyBlock_Example'
+    Filter: #Filter which items can or can't receive enchantments based on name or lore
+      Names: #Matches if the item name is in this list
+        - '&aSome Custom Item Name'
+        - '&e&lAnother &bCustom Item'
+      Lore: #Matches if a single line of item lore is in this list
+        - '&fExample Item Lore'
+        - '&eMore Example Lore'
+      Is-Whitelist: false #If true, enchantments will only be applied to items matching name or lore. If false, enchantments won't be applied to items matching name or lore.
   Costs: #This is where you set the cost of stuff in the shop GUI.
     Scrambler: #The item that is being bought.
       Cost: 800 #How much the item will cost.


### PR DESCRIPTION
Allows user to specify names or lore on items that enchantments can or cannot be applied to.

Adds new options to the config: EnchantmentOptions.Filter.Names, EnchantmentOptions.Filter.Lore, and EnchantmentOptions.Filter.Is-Whitelist.
Adds new API methods to get the filter names, lore, and is-whitelist values.
Adds new method to verify item display name.
Item name matches are exact, including color codes. Lore matches will match any line of lore on an item exactly, including color codes.